### PR TITLE
POSIX compliant hooks

### DIFF
--- a/git-hooks/post-commit
+++ b/git-hooks/post-commit
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/bin/sh
 
 git push origin main

--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -1,6 +1,5 @@
 #!/bin/sh
 #
-# If you are on linux, replace !/bin/sh with !/bin/bash
 #
 # Pull before committing
 # Credential handling options:
@@ -15,12 +14,12 @@
 output=$(git pull --no-rebase)
 
 # Handle non error output as otherwise it gets shown with any exit code by logseq
-if [[ "$output" == "Already up to date." ]]; then
+if [ "$output" = "Already up to date." ]; then
    # no ouput
    exit 0
 else 
    # probably error print it to screen   
-   echo $output
+   echo "${output}"
 fi
 
 git add -A


### PR DESCRIPTION
This PR edits both git-hooks to become fully POSIX compliant. Also, no need to change `#!/bin/sh` to `#!/bin/bash`.