### PR TITLE
Update pre-commit to avoid error messages on pull

### DIFF
--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -11,6 +11,22 @@
 # Redirect output to stderr, uncomment for more output for debugging
 # exec 1>&2
 
+# Fetch latest changes from remote without merging
+git fetch --no-tags
+
+# Attempt merge with automatic conflict resolution
+git merge --no-commit FETCH_HEAD 2> /dev/null
+
+# Check if merge was successful
+if [ $? -eq 0 ]; then
+    # Merge successful, commit changes
+    git commit -m "Automatic merge from pre-commit hook"
+else
+    # Merge conflicts detected, abort commit process
+    echo "Merge conflicts detected. Please resolve conflicts manually and commit."
+    exit 1
+fi
+
 output=$(git pull --no-rebase)
 
 # Handle non error output as otherwise it gets shown with any exit code by logseq


### PR DESCRIPTION
Previously, when pulling new changes from remote, an error would appear due to a head mismatch, from the local repo being behind the remote. This change makes it so that no longer happens, but new changes are still brought in. It does this using Merge. 

Please feel free to improve this code. I am no pro. I just used Google Bard to help get rid of the annoying error messages. Thank you for the resources to integrate Git and Logseq, I love it!